### PR TITLE
Gellerupparken/Toveshøj og Trillegården/Herredsvang

### DIFF
--- a/zones/0212.geojson
+++ b/zones/0212.geojson
@@ -1,0 +1,160 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "background": "På baggrund af flere våbenfund og øvrige indikationer på en konfliktoptrapning mellem grupperinger i det vestlige Aarhus indfører Østjyllands Politi nu visitationszoner i to områder omkring Gellerupparken/Toveshøj og Trillegården/Herredsvang.\nhttps://web.archive.org/web/20211118153950/https://politi.dk/oestjyllands-politi/nyhedsliste/oestjyllands-politi-indfoerer-visitationszoner-i-det-vestlige-aarhus/2021/01/20",
+        "start": "2021-01-20 18.00",
+        "end": "2021-02-12 18.00",
+        "authority": "Østjyllands Politi",
+        "area": "Trillegården/Herredsvang",
+        "extent": "Mod syd:\nHasle Ringvej fra krydset ved Herredsvej til krydset ved Paludan Müllers Vej.\n\nMod øst:\nPaludan Müllers fra krydset ved Hasle Ringvej Vej til krydset ved Bodøvej.\nBodøvej fra krydset ved Paludan Müllers Vej til stien der omkranser Haveforeningen Dybkjær\nStien, inklusive Haveforeningen Dybkjær, til krydset ved Paludan Müllers Vej, inklusive parkeringspladsen ved Aarhus Firma Sport.\nPaludan Müllers Vej fra krydset ved stien der omkranser Haveforeningen Dybkjær og Aarhus Firma sport til krydset ved Marienlystvej\n\nMod nord:\nMarienlystvej fra krydset ved Paludan Müllers Vej, til krydset ved Marienlystvangen, herunder Haveforeningen Marienlyst og stier der omkranser Haveforeningen Marienlyst, samt Marienlyst Parken og stien der omkranser Marienlystparken.\n\nMod vest:\nStien der omkranser Marienlystparken til Fjældevænget.\nFjældevænget fra stien der omkranser Marienlystparken til krydset ved Herredsvej.\nHerredsvej fra krydset ved Fjældevænget til krydset ved Hasle Ringvej.\n\nDe nævnte veje er indbefattet i visitationszonen.",
+        "validation": "Nyhedsmedie"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              10.166666507720947,
+              56.176688348487424
+            ],
+            [
+              10.15709638595581,
+              56.178694898586485
+            ],
+            [
+              10.15434980392456,
+              56.18132236511837
+            ],
+            [
+              10.15486478805542,
+              56.182015030883
+            ],
+            [
+              10.1518177986145,
+              56.184212370580504
+            ],
+            [
+              10.151560306549072,
+              56.18507216491374
+            ],
+            [
+              10.155766010284424,
+              56.18672005021297
+            ],
+            [
+              10.156152248382568,
+              56.18667228641746
+            ],
+            [
+              10.156238079071045,
+              56.18683945944164
+            ],
+            [
+              10.156624317169188,
+              56.187149921697305
+            ],
+            [
+              10.158684253692627,
+              56.18688722302907
+            ],
+            [
+              10.161184072494507,
+              56.18654093567331
+            ],
+            [
+              10.162020921707153,
+              56.18636182029763
+            ],
+            [
+              10.162578821182251,
+              56.18608717509787
+            ],
+            [
+              10.163050889968872,
+              56.18589611640835
+            ],
+            [
+              10.163480043411255,
+              56.18581252793258
+            ],
+            [
+              10.164574384689331,
+              56.18606329281369
+            ],
+            [
+              10.165454149246216,
+              56.185334876006934
+            ],
+            [
+              10.16682744026184,
+              56.184451204271895
+            ],
+            [
+              10.169316530227661,
+              56.18325702095214
+            ],
+            [
+              10.170239210128784,
+              56.182803221548006
+            ],
+            [
+              10.171784162521362,
+              56.182074742863655
+            ],
+            [
+              10.173178911209106,
+              56.18125070932585
+            ],
+            [
+              10.174187421798706,
+              56.181656757048145
+            ],
+            [
+              10.174916982650755,
+              56.181800066983385
+            ],
+            [
+              10.174981355667114,
+              56.18109545464975
+            ],
+            [
+              10.17659068107605,
+              56.18158510187988
+            ],
+            [
+              10.178543329238892,
+              56.179710077430265
+            ],
+            [
+              10.177255868911743,
+              56.17925623608904
+            ],
+            [
+              10.176740884780884,
+              56.17849185959597
+            ],
+            [
+              10.179315805435179,
+              56.17685556500157
+            ],
+            [
+              10.17959475517273,
+              56.17658085177227
+            ],
+            [
+              10.175796747207642,
+              56.17561336779069
+            ],
+            [
+              10.165518522262573,
+              56.173690271679575
+            ]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/zones/0213.geojson
+++ b/zones/0213.geojson
@@ -1,0 +1,152 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "background": "På baggrund af flere våbenfund og øvrige indikationer på en konfliktoptrapning mellem grupperinger i det vestlige Aarhus indfører Østjyllands Politi nu visitationszoner i to områder omkring Gellerupparken/Toveshøj og Trillegården/Herredsvang.\nhttps://web.archive.org/web/20211118153950/https://politi.dk/oestjyllands-politi/nyhedsliste/oestjyllands-politi-indfoerer-visitationszoner-i-det-vestlige-aarhus/2021/01/20",
+        "start": "2021-01-20 18.00",
+        "end": "2021-02-12 18.00",
+        "authority": "Østjyllands Politi",
+        "area": "Gellerupparken/Toveshøj",
+        "extent": "Mod syd:\nSilkeborgvej fra krydset ved Hejredalsvej til krydset ved Åby Ringvej.\n\nMod øst:\nÅby Ringvej fra krydset ved Silkeborgvej til krydset ved Jernaldervej.\n\nMod nord:\nJernaldervej fra krydset ved Silkeborgvej til krydset ved Holmstrupgårdvej.\n\nMod vest:\nHolmstrupgårdvej fra krydset ved Jernaldervej til krydset ved Edwin Rahrs Vej.\nEdwin Rahrs Vej fra krydset ved Holmstrupgårdvej til Krydset ved Hejredalsvej.\nHejredalsvej fra krydset ved Edwin Rahrs Vej til krydset ved Silkeborgvej.\n\nDe nævnte veje er indbefattet i visitationszonen. ",
+        "validation": "Nyhedsmedie"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              10.119545459747314,
+              56.175302812207704
+            ],
+            [
+              10.12190580368042,
+              56.17525503420275
+            ],
+            [
+              10.124480724334715,
+              56.174944475721134
+            ],
+            [
+              10.13486623764038,
+              56.17358276656959
+            ],
+            [
+              10.149414539337158,
+              56.17105033692063
+            ],
+            [
+              10.151431560516357,
+              56.17057250127528
+            ],
+            [
+              10.154178142547607,
+              56.169401778813686
+            ],
+            [
+              10.149285793304443,
+              56.166223923636714
+            ],
+            [
+              10.147397518157959,
+              56.16502917322528
+            ],
+            [
+              10.14585256576538,
+              56.16361931993536
+            ],
+            [
+              10.144779682159424,
+              56.162472282469814
+            ],
+            [
+              10.14413595199585,
+              56.161301313058026
+            ],
+            [
+              10.143535137176514,
+              56.15950894380315
+            ],
+            [
+              10.143406391143799,
+              56.158218386154395
+            ],
+            [
+              10.143492221832275,
+              56.15656927717607
+            ],
+            [
+              10.144178867340088,
+              56.1534620679329
+            ],
+            [
+              10.136840343475342,
+              56.15296011055707
+            ],
+            [
+              10.127227306365967,
+              56.152362533702565
+            ],
+            [
+              10.117571353912354,
+              56.152697177886026
+            ],
+            [
+              10.11692762374878,
+              56.15394011648013
+            ],
+            [
+              10.118944644927979,
+              56.154107432066496
+            ],
+            [
+              10.120832920074463,
+              56.154418159079675
+            ],
+            [
+              10.122549533843992,
+              56.15503960556735
+            ],
+            [
+              10.124008655548096,
+              56.15592395439312
+            ],
+            [
+              10.125081539154053,
+              56.157262389573276
+            ],
+            [
+              10.125939846038818,
+              56.158242285764096
+            ],
+            [
+              10.12765645980835,
+              56.159389449545905
+            ],
+            [
+              10.130016803741455,
+              56.16077556007787
+            ],
+            [
+              10.13164758682251,
+              56.16194654551691
+            ],
+            [
+              10.121090412139893,
+              56.16309359868236
+            ],
+            [
+              10.119202136993408,
+              56.17059639319875
+            ],
+            [
+              10.119030475616455,
+              56.17365443667635
+            ]
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Forglemt visitationszone fra sidste vinter.

[Link](https://web.archive.org/web/20211118153950/https://politi.dk/oestjyllands-politi/nyhedsliste/oestjyllands-politi-indfoerer-visitationszoner-i-det-vestlige-aarhus/2021/01/20)