### PR TITLE
Visitationszone forlænget

### DIFF
--- a/zones/0240.geojson
+++ b/zones/0240.geojson
@@ -6,7 +6,7 @@
             "properties": {
                 "background": "Baggrunden for at oprette de to zoner er en igangv\u00e6rende konflikt mellem to kriminelle grupperinger fra rocker- og bandemilj\u00f8et. L\u00f8rdagens skyderi i Pusher Street er den seneste voldelige handling i konflikten.\n\nKilde: https://politi.dk/koebenhavns-politi/nyhedsliste/koebenhavns-politi-etablerer-to-visitationszoner/2023/08/28",
                 "start": "2023-08-28 18:00",
-                "end": "2023-11-06 18:00",
+                "end": "2023-11-20 18:00",
                 "authority": "K\u00f8benhavns Politi",
                 "area": "Dele af N\u00f8rrebro og Nordvest",
                 "extent": "M\u00e5gevej \u2013 Glasvej \u2013 Frederiksborgvej \u2013 Bisiddervej \u2013 Lygten \u2013 Tagensvej \u2013 Rovsingsgade \u2013 Vermundsgade \u2013 Lers\u00f8 Parkall\u00e9 \u2013 Jagtvej \u2013 Tagensvej \u2013 Blegdamsvej \u2013 F\u00e6lledvej \u2013 N\u00f8rrebrogade \u2013 Peblinge Dossering \u2013 \u00c5boulevard \u2013 \u00c5gade \u2013 Jagtvej \u2013 Borups All\u00e9 \u2013 M\u00e5gevej",


### PR DESCRIPTION
Kilde: https://politi.dk/koebenhavns-politi/nyhedsliste/koebenhavns-politi-forlaenger-visitationszoner-og-lukning-af-rockerbandetilholdssteder/2023/11/06