### PR TITLE
Visitationszone forlænget

### DIFF
--- a/zones/0239.geojson
+++ b/zones/0239.geojson
@@ -6,7 +6,7 @@
             "properties": {
                 "background": "Baggrunden for at oprette de to zoner er en igangv\u00e6rende konflikt mellem to kriminelle grupperinger fra rocker- og bandemilj\u00f8et. L\u00f8rdagens skyderi i Pusher Street er den seneste voldelige handling i konflikten.\n\n(Kilde:  https://politi.dk/koebenhavns-politi/nyhedsliste/koebenhavns-politi-etablerer-to-visitationszoner/2023/08/28)",
                 "start": "2023-08-28 18:00",
-                "end": "2023-11-06 18:00",
+                "end": "2023-11-20 18:00",
                 "authority": "K\u00f8benhavns Politi",
                 "area": "Christiania og en del af Amager",
                 "extent": "Prinsessegade \u2013 Refshalevej \u2013 Forlandet \u2013 Kl\u00f8vermarksvej \u2013 Raffinaderivej \u2013 Prags Boulevard \u2013 Strandlodsvej \u2013 Lergravsvej \u2013 \u00d8strigsgade \u2013 \u00d8resundvej \u2013 Amagerbrogade \u2013 Christmas M\u00f8llers Plads - Torvegade \u2013 Prinsessegade",


### PR DESCRIPTION
Kilde: https://politi.dk/koebenhavns-politi/nyhedsliste/koebenhavns-politi-forlaenger-visitationszoner-og-lukning-af-rockerbandetilholdssteder/2023/11/06